### PR TITLE
Add NEURON_COLORS & SYNAPSE_COLORS to module export

### DIFF
--- a/src/lib/config/Colors.js
+++ b/src/lib/config/Colors.js
@@ -1,0 +1,21 @@
+export const NEURON_COLORS = [
+  "#9400D3",
+  "#DAA520",
+  "#97d0b5",
+  "#76acf3",
+  "#FF6347",
+  "#4C56B3",
+  "#D9C226",
+  "#263DD9",
+];
+
+export const SYNAPSE_COLORS = [
+  "#FF6347",
+  "#DAA520",
+  "#97d0b5",
+  "#76acf3",
+  "#9400D3",
+  "#4C56B3",
+  "#D9C226",
+  "#263DD9",
+];

--- a/src/lib/contexts/GlobalContext.js
+++ b/src/lib/contexts/GlobalContext.js
@@ -1,5 +1,7 @@
 import React, { useState } from "react";
 
+import {NEURON_COLORS, SYNAPSE_COLORS } from "../config/Colors";
+
 export const AppContext = React.createContext(null);
 
 // Step 2: Create a ContextWrapper component that has to be the parent of every consumer.
@@ -10,34 +12,8 @@ export const ContextWrapper = (props) => {
   const [focusedMotif, setFocusedMotif] = useState(null);
   const [motifQuery, setMotifQuery] = useState();
   const [abstractionLevel, setAbstractionLevel] = useState();
-  const [neuronColors, setNeuronColors] = useState([
-    // "#7e2fd0",
-    // "#81D02F",
-    // "#34AFCB",
-    // "#B3A94C",
-    // "#4C56B3",
-    // "#D9C226",
-    // "#263DD9",
-    // "#CB5034",
-    "#9400D3",
-    "#DAA520",
-    "#97d0b5",
-    "#76acf3",
-    "#FF6347",
-    "#4C56B3",
-    "#D9C226",
-    "#263DD9",
-  ]);
-  const [synapseColors, setSynapseColors] = useState([
-    "#FF6347",
-    "#DAA520",
-    "#97d0b5",
-    "#76acf3",
-    "#9400D3",
-    "#4C56B3",
-    "#D9C226",
-    "#263DD9",
-  ]);
+  const [neuronColors, setNeuronColors] = useState(NEURON_COLORS);
+  const [synapseColors, setSynapseColors] = useState(SYNAPSE_COLORS);
 
   const [highlightColor, setHighlightColor] = useState("#0000ff");
 

--- a/src/lib/index.js
+++ b/src/lib/index.js
@@ -1,3 +1,4 @@
 import Sketch from './Sketch'
+import {NEURON_COLORS, SYNAPSE_COLORS } from "./config/Colors";
 
-export { Sketch };
+export { Sketch, NEURON_COLORS, SYNAPSE_COLORS };


### PR DESCRIPTION
This gives other applications, that are importing this component, access to the list of colors used in the sketch interface. This way the application can apply those colors elsewhere, without having to maintain a duplicate list.